### PR TITLE
Fix Omada EAP controller docker build

### DIFF
--- a/.github/workflows/build_omada_controller.yml
+++ b/.github/workflows/build_omada_controller.yml
@@ -38,4 +38,4 @@ jobs:
       context: dockerfiles/omada_controller
       file: dockerfiles/omada_controller/dockerfile
       build-args: |
-        GETDNS_RELEASE=${{ inputs.omada_tar_url || 'https://static.tp-link.com/upload/software/2025/202510/20251031/Omada_SDN_Controller_v6.0.0.24_linux_x64_20251027202524.tar.gz' }}
+        OMADA_TAR_URL=${{ inputs.omada_tar_url || 'https://static.tp-link.com/upload/software/2026/202601/20260121/Omada_Network_Application_v6.1.0.19_linux_x64_20260117100056.tar.gz' }}

--- a/.github/workflows/build_omada_controller.yml
+++ b/.github/workflows/build_omada_controller.yml
@@ -38,4 +38,4 @@ jobs:
       context: dockerfiles/omada_controller
       file: dockerfiles/omada_controller/dockerfile
       build-args: |
-        GETDNS_RELEASE=${{ inputs.omada_tar_url || 'https://static.tp-link.com/upload/software/2024/202402/20240227/Omada_SDN_Controller_v5.13.30.8_linux_x64.tar.gz' }}
+        GETDNS_RELEASE=${{ inputs.omada_tar_url || 'https://static.tp-link.com/upload/software/2025/202510/20251031/Omada_SDN_Controller_v6.0.0.24_linux_x64_20251027202524.tar.gz' }}

--- a/dockerfiles/omada_controller/dockerfile
+++ b/dockerfiles/omada_controller/dockerfile
@@ -17,7 +17,7 @@ RUN apt-get update \
     curl \
     gpg
 
-ARG MONGO_DB_VERSION=7.0
+ARG MONGO_DB_VERSION=8.0
 ARG MONGO_DB_REPO_KEY_PATH=${KEY_RING_DIR}/mongodb-server-${MONGO_DB_VERSION}.gpg
 RUN curl -fsSL https://pgp.mongodb.com/server-${MONGO_DB_VERSION}.asc \
   | gpg -o ${MONGO_DB_REPO_KEY_PATH} --dearmor
@@ -31,7 +31,7 @@ RUN echo "deb [signed-by=${ADOPTIUM_REPO_KEY_PATH}] https://packages.adoptium.ne
   | tee ${APT_SOURCES_DIR}/adoptium.list
 
 WORKDIR ${INSTALL_DIR}
-ARG OMADA_TAR_URL=https://static.tp-link.com/upload/software/2023/202309/20230920/Omada_SDN_Controller_v5.12.7_linux_x64.tar.gz
+ARG OMADA_TAR_URL=https://static.tp-link.com/upload/software/2026/202601/20260121/Omada_Network_Application_v6.1.0.19_linux_x64_20260117100056.tar.gz
 RUN curl -fsSL ${OMADA_TAR_URL} | tar -xz -C . --strip-components=1
 RUN sed -i "/\${link_name} start/d" ./install.sh
 
@@ -60,7 +60,7 @@ RUN apt-get update \
     procps \
     curl \
     mongodb-org \
-    temurin-8-jre \
+    temurin-17-jre \
     jsvc \
     libcap2-bin \
   && rm -rf /var/lib/apt/lists/*
@@ -87,10 +87,12 @@ EXPOSE 29811/tcp
 EXPOSE 29812/tcp
 # Omada EAP firmware upgrade
 EXPOSE 29813/tcp
-# Omada EAP device management?
+# Omada EAP device management
 EXPOSE 29814/tcp
 EXPOSE 29815/tcp
 EXPOSE 29816/tcp
+EXPOSE 29816/tcp
+EXPOSE 29817/tcp
 
 WORKDIR ${INSTALL_DIR}
 CMD [ "/bin/bash", "-c", "set -e; ./bin/control.sh start; sleep infinity;" ]

--- a/dockerfiles/omada_controller/dockerfile
+++ b/dockerfiles/omada_controller/dockerfile
@@ -1,5 +1,5 @@
 # Omada EAP controller expects MongoDB 4.x which was last available in Debian 10.
-ARG DEBIAN_VERSION=buster
+ARG DEBIAN_VERSION=trixie
 ARG KEY_RING_DIR=/usr/share/keyrings
 ARG APT_SOURCES_DIR=/etc/apt/sources.list.d
 ARG INSTALL_DIR=/opt/tplink

--- a/dockerfiles/omada_controller/dockerfile
+++ b/dockerfiles/omada_controller/dockerfile
@@ -1,5 +1,4 @@
-# Omada EAP controller expects MongoDB 4.x which was last available in Debian 10.
-ARG DEBIAN_VERSION=trixie
+ARG DEBIAN_VERSION=bookworm
 ARG KEY_RING_DIR=/usr/share/keyrings
 ARG APT_SOURCES_DIR=/etc/apt/sources.list.d
 ARG INSTALL_DIR=/opt/tplink
@@ -18,7 +17,7 @@ RUN apt-get update \
     curl \
     gpg
 
-ARG MONGO_DB_VERSION=4.4
+ARG MONGO_DB_VERSION=7.0
 ARG MONGO_DB_REPO_KEY_PATH=${KEY_RING_DIR}/mongodb-server-${MONGO_DB_VERSION}.gpg
 RUN curl -fsSL https://pgp.mongodb.com/server-${MONGO_DB_VERSION}.asc \
   | gpg -o ${MONGO_DB_REPO_KEY_PATH} --dearmor

--- a/roles/omada_controller/templates/docker-compose.yml.j2
+++ b/roles/omada_controller/templates/docker-compose.yml.j2
@@ -28,7 +28,7 @@ services:
     ports:
       - 27001:27001/udp
       - 29810:29810/udp
-      - 29811-29816:29811-29816/tcp
+      - 29811-29817:29811-29817/tcp
     environment:
       HTTP_PORT: {{ omada_http_port }}
       AUTOBACKUP_DIR: /opt/tplink/autobackup/


### PR DESCRIPTION
Debian 10 is no longer supported. Omada controller now supports Debian 12.