### PR TITLE
Fix Terraform-managed Proxmox VM hostnames

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Install Ansible dependencies
         run: |
           pipx install ansible-core
-          pipx inject ansible-core requests python-dateutil netaddr
+          pipx inject ansible-core requests python-dateutil netaddr proxmoxer
           echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Install Ansible collections

--- a/terraform/cloud-init.tftpl
+++ b/terraform/cloud-init.tftpl
@@ -1,4 +1,6 @@
 #cloud-config
+hostname: ${hostname}
+prefer_fqdn_over_hostname: true
 users:
   - name: deployment
     groups:

--- a/terraform/hetzner.tf
+++ b/terraform/hetzner.tf
@@ -28,6 +28,7 @@ resource "hcloud_server" "nodes" {
   firewall_ids = [hcloud_firewall.ssh-only-firewall.id]
   user_data = templatefile("${path.module}/cloud-init.tftpl",
     {
+      hostname       = each.key
       ssh_keys       = values(var.ssh_public_keys)
       extra_packages = []
       run_commands   = []

--- a/terraform/proxmox.tf
+++ b/terraform/proxmox.tf
@@ -1,16 +1,18 @@
 resource "proxmox_virtual_environment_file" "cloud_config" {
+  for_each     = var.proxmox_vms
   content_type = "snippets"
   datastore_id = "local"
   node_name    = var.proxmox_node_name
 
   source_raw {
-    data = templatefile("${path.module}/cloud-init.tftpl",
-      {
-        ssh_keys       = values(var.ssh_public_keys)
-        extra_packages = ["qemu-guest-agent"]
-        run_commands   = ["systemctl enable qemu-guest-agent", "systemctl start qemu-guest-agent"]
+    data = templatefile("${path.module}/cloud-init.tftpl", {
+      hostname       = each.key
+      ssh_keys       = values(var.ssh_public_keys)
+      extra_packages = ["qemu-guest-agent"]
+      run_commands   = ["systemctl enable qemu-guest-agent", "systemctl start qemu-guest-agent"]
     })
-    file_name = "cloud-init.yaml"
+
+    file_name = "cloud-init-${each.key}.yaml"
   }
 }
 
@@ -68,7 +70,7 @@ resource "proxmox_virtual_environment_vm" "virtual_machines" {
       }
     }
     datastore_id      = "local-lvm"
-    user_data_file_id = proxmox_virtual_environment_file.cloud_config.id
+    user_data_file_id = proxmox_virtual_environment_file.cloud_config[each.key].id
   }
 }
 


### PR DESCRIPTION
Proxmox requires the hostname set explicitly in cloud-init. Add hostname to fix DNS resolution for Terraform-managed VMs.